### PR TITLE
Rework requirements checks

### DIFF
--- a/inc/packages/admin/info.php
+++ b/inc/packages/admin/info.php
@@ -370,7 +370,7 @@ function add_requirement_notices( ReleaseDocument $release ) : void {
 				'additional_classes' => [ 'notice-alt' ],
 			]
 		);
-	} elseif ( isset( $unmet_requires['env:wp']) ) {
+	} elseif ( isset( $unmet_requires['env:wp'] ) ) {
 		$compatible_wp_notice_message = __( '<strong>Error:</strong> This plugin <strong>requires a newer version of WordPress</strong>.', 'fair' );
 		if ( current_user_can( 'update_core' ) ) {
 			$compatible_wp_notice_message .= sprintf(

--- a/inc/packages/namespace.php
+++ b/inc/packages/namespace.php
@@ -322,4 +322,107 @@ function pick_artifact_by_lang( array $artifacts, ?string $locale = null ) {
 	return apply_filters( 'fair.packages.pick_artifact_by_lang', $selected, $artifacts, $locale, $langs );
 }
 
+/**
+ * Get version requirements.
+ *
+ * @param ReleaseDocument $release Release document.
+ *
+ * @return array
+ */
+function version_requirements( ReleaseDocument $release ) {
+	$required_versions = [];
+	foreach ( $release->requires as $pkg => $vers ) {
+		$vers = preg_replace( '/^[^0-9]+/', '', $vers );
+		if ( $pkg === 'env:php' ) {
+			$required_versions['requires_php'] = $vers;
+		}
+		if ( $pkg === 'env:wp' ) {
+			$required_versions['requires_wp'] = $vers;
+		}
+	}
+	foreach ( $release->suggests as $pkg => $vers ) {
+		$vers = preg_replace( '/^[^0-9]+/', '', $vers );
+		if ( $pkg === 'env:wp' ) {
+			$required_versions['tested_to'] = $vers;
+		}
+	}
+
+	return $required_versions;
+}
+
+/**
+ * Get unmet requirements.
+ *
+ * @param array $requirements Requirements to check. Map of package names to requirement strings.
+ * @return array Map of package names to unmet requirements.
+ */
+function get_unmet_requirements( array $requirements ) : array {
+	$unmet = [];
+	foreach ( $requirements as $pkg => $req ) {
+		$req = trim( $req );
+		$comp_spn = strspn( $req, '<>=!' );
+		if ( $comp_spn === 0 ) {
+			// Invalid requirement, for now.
+			continue;
+		}
+
+		$comp = trim( substr( $req, 0, $comp_spn ) );
+		$ver = trim( substr( $req, $comp_spn ) );
+
+		switch ( true ) {
+			case $pkg === 'env:wp':
+				// From is_wp_version_compatible()
+				// We use our own copy to allow passing $comp
+				if (
+					defined( 'WP_RUN_CORE_TESTS' )
+					&& WP_RUN_CORE_TESTS
+					&& isset( $GLOBALS['_wp_tests_wp_version'] )
+				) {
+					$wp_version = $GLOBALS['_wp_tests_wp_version'];
+				} else {
+					$wp_version = wp_get_wp_version();
+				}
+
+				$valid = version_compare( $wp_version, $ver, $comp );
+				if ( ! $valid ) {
+					$unmet[ $pkg ] = $req;
+				}
+				break;
+
+			case $pkg === 'env:php':
+				$valid = version_compare( PHP_VERSION, $ver, $comp );
+				if ( ! $valid ) {
+					$unmet[ $pkg ] = $req;
+				}
+				break;
+
+			case str_starts_with( $pkg, 'env:php-' ):
+				// todo: check extensions.
+				break;
+
+			case str_starts_with( $pkg, 'env:' ):
+				// todo: check other env, or fail.
+				break;
+
+			default:
+				// todo: check packages.
+				break;
+		}
+	}
+
+	return $unmet;
+}
+
+/**
+ * Check if a release meets the requirements.
+ *
+ * @param ReleaseDocument $release Release document.
+ *
+ * @return bool True if the release meets the requirements, false otherwise.
+ */
+function check_requirements( ReleaseDocument $release ) {
+	$requires = get_unmet_requirements( (array) $release->requires );
+	return empty( $requires );
+}
+
 // phpcs:enable

--- a/inc/updater/class-updater.php
+++ b/inc/updater/class-updater.php
@@ -9,7 +9,7 @@ namespace FAIR\Updater;
 
 use const FAIR\Packages\SERVICE_ID;
 
-use function FAIR\Packages\Admin\Info\check_requirements;
+use FAIR\Packages;
 use function FAIR\Packages\fetch_metadata_doc;
 use function FAIR\Packages\fetch_package_metadata;
 use function FAIR\Packages\get_did_document;
@@ -314,7 +314,7 @@ class Updater {
 		$rel_path = plugin_basename( $this->filepath );
 		$response = $this->get_update_data();
 		$response = 'plugin' === $this->type ? (object) $response : $response;
-		$is_compatible = check_requirements( $this->release );
+		$is_compatible = Packages\check_requirements( $this->release );
 
 		if ( $is_compatible && version_compare( $this->release->version, $this->local_version, '>' ) ) {
 			$transient->response[ $rel_path ] = $response;


### PR DESCRIPTION
This breaks the checks for requirements away from the notices, as well as introducing more robust handling for different requirement constraints (<, <=, >, >=, =, ==, !=).

Fixes the bug with notices appearing where they shouldn't.