### PR TITLE
Pass package variables and no globals

### DIFF
--- a/inc/packages/class-upgrader.php
+++ b/inc/packages/class-upgrader.php
@@ -242,11 +242,13 @@ class Upgrader extends WP_Upgrader {
 		$artifact = pick_artifact_by_lang( $this->release->artifacts->package );
 
 		/**
-		 * Fires before upgrader_pre_download to use object data in filters.
+		 * Fires before upgrader_pre_download to use package data in filters.
 		 *
-		 * @param Upgrader Current class object.
+		 * @param string $did DID.
+		 * @param string $filepath Absolute file path to package.
+		 * @param string $type plugin|theme.
 		 */
-		do_action( 'get_fair_document_data', $this );
+		do_action( 'get_fair_package_data', $this->did, $this->filepath, $this->type );
 		add_filter( 'upgrader_pre_download', 'FAIR\\Updater\\upgrader_pre_download' );
 
 		// Download the package.

--- a/inc/updater/class-updater.php
+++ b/inc/updater/class-updater.php
@@ -133,11 +133,13 @@ class Updater {
 		}
 
 		/**
-		 * Fires before upgrader_pre_download to use object data in filters.
+		 * Fires before upgrader_pre_download to use package data in filters.
 		 *
-		 * @param Updater Current class object.
+		 * @param string $did DID.
+		 * @param string $filepath Absolute file path to package.
+		 * @param string $type plugin|theme.
 		 */
-		do_action( 'get_fair_document_data', $this );
+		do_action( 'get_fair_package_data', $this->did, $this->filepath, $this->type );
 		add_filter( 'upgrader_pre_download', __NAMESPACE__ . '\\upgrader_pre_download' );
 	}
 

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -37,9 +37,8 @@ function bootstrap() {
  * @return void
  */
 function get_fair_document_data( $did, $filepath, $type ) : void {
-	$release = wp_cache_get( UPDATE_PACKAGE );
-
 	$packages = [];
+	$release = wp_cache_get( UPDATE_PACKAGE );
 	$file = $type === 'plugin' ? plugin_basename( $filepath ) : dirname( plugin_basename( $filepath ) );
 
 	// phpcs:disable HM.Security.NonceVerification.Recommended

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -21,7 +21,9 @@ use WP_Error;
  */
 function bootstrap() {
 	add_action( 'init', __NAMESPACE__ . '\\run' );
-	add_action( 'get_fair_document_data', __NAMESPACE__ . '\\get_fair_document_data', 10, 1 );
+	add_action( 'get_fair_package_data', __NAMESPACE__ . '\\get_fair_document_data', 10, 3 );
+	add_action( 'wp_ajax_update-plugin', __NAMESPACE__ . '\\get_fair_document_data', 10, 3 );
+	// TODO: Will need to add hooks for themes.
 }
 
 /**

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -28,7 +28,7 @@ function bootstrap() {
 }
 
 /**
- * Get FAIR MetadataDocument and ReleaseDocument data.
+ * Get FAIR ReleaseDocument data.
  *
  * @param string $did DID.
  * @param string $filepath Absolute file path to package.

--- a/inc/updater/namespace.php
+++ b/inc/updater/namespace.php
@@ -9,7 +9,6 @@ namespace FAIR\Updater;
 
 use const FAIR\Packages\Admin\ACTION_INSTALL;
 
-use FAIR\Packages\Upgrader;
 use function FAIR\Packages\fetch_package_metadata;
 use function FAIR\Packages\get_did_document;
 use function FAIR\Packages\pick_release;
@@ -47,12 +46,12 @@ function get_fair_document_data( $did, $filepath, $type ) : void {
 	if ( isset( $_REQUEST['action'] ) ) {
 		// Runs on DID install of package.
 		if ( $_REQUEST['action'] === ACTION_INSTALL ) {
-			if ( isset( $_REQUEST['id']) ) {
+			if ( isset( $_REQUEST['id'] ) ) {
 				$did = sanitize_text_field( wp_unslash( $_REQUEST['id'] ) );
 				$release[ $did ] = get_release_from_did( $did );
 			}
 		}
-		$packages = $_REQUEST['checked'] ?? [];
+		$packages = isset( $_REQUEST['checked'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['checked'] ) ) : [];
 		if ( 'update-selected' === $_REQUEST['action'] ) {
 			$packages = 'plugin' === $type && isset( $_REQUEST['plugins'] ) ? array_map( 'dirname', explode( ',', sanitize_text_field( wp_unslash( $_REQUEST['plugins'] ) ) ) ) : [];
 			$packages = 'theme' === $type && isset( $_REQUEST['themes'] ) ? explode( ',', sanitize_text_field( wp_unslash( $_REQUEST['themes'] ) ) ) : $packages;


### PR DESCRIPTION
Pass the Updater/Upgrader package variables from hook. No getter needed.

Removed global in favor of using wp_cache_*